### PR TITLE
[Feat/#56] add title to count response

### DIFF
--- a/src/main/java/animal/diary/controller/RecordController.java
+++ b/src/main/java/animal/diary/controller/RecordController.java
@@ -75,7 +75,7 @@ public class RecordController {
             - 기력 상태는 반려동물의 에너지 수준을 나타냅니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "기력 상태 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "기력 상태 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseApi.EnergyAndAppetiteResponseApi.class))
             }),
@@ -107,7 +107,7 @@ public class RecordController {
             - 식욕 상태는 반려동물의 식욕 수준을 나타냅니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "식욕 상태 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "식욕 상태 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseApi.EnergyAndAppetiteResponseApi.class))
             }),
@@ -139,7 +139,7 @@ public class RecordController {
             - 호흡 수는 반려동물의 호흡 횟수를 나타냅니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "호흡 수 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "호흡 수 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.RRAndHeartRateResponseDTO.class))
             }),
@@ -171,7 +171,7 @@ public class RecordController {
             - 심박수는 반려동물의 심장 박동 수를 나타냅니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "심박수 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "심박수 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.RRAndHeartRateResponseDTO.class))
             }),
@@ -203,7 +203,7 @@ public class RecordController {
             - 기절 상태는 반려동물이 기절했는지 여부를 나타냅니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "기절 상태 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "기절 상태 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.SyncopeResponseDTO.class))
             }),
@@ -296,7 +296,7 @@ public class RecordController {
             - 이미지는 최대 10장까지 업로드 가능합니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "특이사항 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "특이사항 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.SignificantResponseDTO.class))
             }),
@@ -337,7 +337,7 @@ public class RecordController {
             - 이미지는 단일 이미지만 업로드 가능합니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "경련 상태 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "경련 상태 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.ConvulsionResponseDTO.class))
             }),
@@ -371,7 +371,7 @@ public class RecordController {
             - 이미지는 단일 이미지만 업로드 가능합니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "이상 소리 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "이상 소리 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.SoundResponseDTO.class))
             }),
@@ -407,7 +407,7 @@ public class RecordController {
             - 이미지는 최대 10장까지 업로드 가능합니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "콧물 상태 기록 성공", content = {
+            @ApiResponse(responseCode = "201", description = "콧물 상태 기록 성공", content = {
                     @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.SnotResponseDTO.class))
             }),

--- a/src/main/java/animal/diary/dto/RecordResponseDTO.java
+++ b/src/main/java/animal/diary/dto/RecordResponseDTO.java
@@ -19,8 +19,11 @@ public class RecordResponseDTO {
     @Builder
     @Getter
     public static class WeightResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
         private Long petId;
+        @Schema(description = "몸무게", example = "5.5")
         private Float weight;
+        @Schema(description = "몸무게 기록 생성 시간", example = "2023-10-01T12:00:00")
         private LocalDateTime createdAt;
 
         public static WeightResponseDTO weightToDTO(Weight weight) {
@@ -34,8 +37,11 @@ public class RecordResponseDTO {
     @Builder
     @Getter
     public static class EnergyAndAppetiteResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
         private Long petId;
+        @Schema(description = "에너지/식욕 상태", example = "HIGH")
         private String state;
+        @Schema(description = "에너지/식욕 기록 생성 시간", example = "2023-10-01T12:00:00")
         private LocalDateTime createdAt;
 
         public static EnergyAndAppetiteResponseDTO energyToDTO(Energy energy) {
@@ -58,8 +64,11 @@ public class RecordResponseDTO {
     @Builder
     @Getter
     public static class RRAndHeartRateResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
         private Long petId;
+        @Schema(description = "호흡수/심박수", example = "20")
         private Integer count;
+        @Schema(description = "호흡수/심박수 기록 생성 시간", example = "2023-10-01T12:00:00")
         private LocalDateTime createdAt;
 
         public static RRAndHeartRateResponseDTO respiratoryRateToDTO(RespiratoryRate respiratoryRate) {
@@ -82,8 +91,11 @@ public class RecordResponseDTO {
     @Builder
     @Getter
     public static class SyncopeResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
         private Long petId;
+        @Schema(description = "실신 상태", example = "O")
         private String state;
+        @Schema(description = "실신 기록 생성 시간", example = "2023-10-01T12:00:00")
         private LocalDateTime createdAt;
 
         public static SyncopeResponseDTO syncopeToDTO(Syncope syncope) {
@@ -151,9 +163,17 @@ public class RecordResponseDTO {
     @Builder
     @Getter
     public static class ConvulsionResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
         private Long petId;
+        @Schema(description = "경련 상태 O, X", example = "O")
         private String state;
+        //    INCONTINENCE("배변실수"),
+        //    DROOLING("침흘림"),
+        //    UNCONSCIOUS("의식없음"),
+        //    NORMAL("추가 증상 없음");
+        @Schema(description = "경련 시 이상 상태 목록 INCONTINENCE(\"배변실수\"), DROOLING(\"침흘림\"), UNCONSCIOUS(\"의식없음\"), NORMAL(\"추가 증상 없음\")", example = "[\"INCONTINENCE\", \"DROOLING\"]")
         private List<String> abnormalState;
+        @Schema(description = "경련 기록 생성 시간", example = "2023-10-01T12:00:00")
         private LocalDateTime createdAt;
 
         public static ConvulsionResponseDTO convulsionToDTO(Convulsion convulsion) {
@@ -171,8 +191,11 @@ public class RecordResponseDTO {
     @Builder
     @Getter
     public static class SoundResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
         private Long petId;
+        @Schema(description = "소리 제목", example = "기침 소리")
         private String title;
+        @Schema(description = "소리 기록 생성 시간", example = "2023-10-01T12:00:00")
         private LocalDateTime createdAt;
 
         public static SoundResponseDTO soundToDTO(Sound sound) {
@@ -187,8 +210,12 @@ public class RecordResponseDTO {
     @Builder
     @Getter
     public static class SnotResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
         private Long petId;
+        //CLEAR("맑음"), MUCUS("탁함"), BLOODY("피섞임");
+        @Schema(description = "콧물 상태 CLEAR(\"맑음\"), MUCUS(\"탁함\"), BLOODY(\"피섞임\")", example = "CLEAR")
         private String state;
+        @Schema(description = "콧물 기록 생성 시간", example = "2023-10-01T12:00:00")
         private LocalDateTime createdAt;
 
         public static SnotResponseDTO snotToDTO(Snot snot) {

--- a/src/main/java/animal/diary/dto/ResponseDateDTO.java
+++ b/src/main/java/animal/diary/dto/ResponseDateDTO.java
@@ -55,7 +55,9 @@ public class ResponseDateDTO {
     @Builder
     @Getter
     public static class StateResponse {
+        @Schema(description = "일기 ID", example = "1")
         private Long diaryId;
+        @Schema(description = "상태", example = "HIGH")
         private String state;
         @Schema(type = "string", example = "14:30", description = "기록 시간 (HH:mm)")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
@@ -89,7 +91,11 @@ public class ResponseDateDTO {
     @Builder
     @Getter
     public static class CountResponse {
+        @Schema(description = "일기 ID", example = "1")
         private Long diaryId;
+        @Schema(description = "제목", example = "20회/60초")
+        private String title;
+        @Schema(description = "호흡수/심박수", example = "20")
         private Integer count;
         @Schema(type = "string", example = "14:30", description = "기록 시간 (HH:mm)")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
@@ -98,6 +104,7 @@ public class ResponseDateDTO {
         public static CountResponse respiratoryRateToDTO(RespiratoryRate respiratoryRate) {
             return CountResponse.builder()
                     .diaryId(respiratoryRate.getId())
+                    .title(respiratoryRate.getCount() + "회/60초")
                     .count(respiratoryRate.getCount())
                     .createdTime(respiratoryRate.getCreatedAt().toLocalTime())
                     .build();

--- a/src/main/java/animal/diary/dto/ResponseDateDTO.java
+++ b/src/main/java/animal/diary/dto/ResponseDateDTO.java
@@ -113,6 +113,7 @@ public class ResponseDateDTO {
         public static CountResponse heartRateToDTO(HeartRate heartRate) {
             return CountResponse.builder()
                     .diaryId(heartRate.getId())
+                    .title(heartRate.getCount() + "회/60초")
                     .count(heartRate.getCount())
                     .createdTime(heartRate.getCreatedAt().toLocalTime())
                     .build();


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #56

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
This PR adds a title field to the CountResponse class and improves API documentation by adding @Schema annotations to response DTOs and correcting HTTP status codes from 200 to 201 for record creation endpoints.

- Adds a title field to CountResponse that displays count values in a user-friendly format (e.g., "20회/60초")
- Enhances API documentation with comprehensive @Schema annotations for all response DTO fields
- Corrects HTTP status codes from 200 to 201 for POST endpoints that create new records

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->