### PR TITLE
[Feat/#61] water intake record

### DIFF
--- a/src/main/java/animal/diary/controller/QueryController.java
+++ b/src/main/java/animal/diary/controller/QueryController.java
@@ -444,4 +444,6 @@ public class QueryController {
                 .status(SuccessCode.SUCCESS_GET_RECORD_LIST.getStatus().value())
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_GET_RECORD_LIST, result));
     }
+
+    // =========================================================== 음수량 기록 조회
 }

--- a/src/main/java/animal/diary/controller/QueryController.java
+++ b/src/main/java/animal/diary/controller/QueryController.java
@@ -446,4 +446,35 @@ public class QueryController {
     }
 
     // =========================================================== 음수량 기록 조회
+    @Operation(summary = "음수량 날짜별 조회", description = """
+            특정 날짜의 음수량 기록을 조회합니다.
+            - 필수 필드: petId, date
+            - date: 조회할 날짜 (yyyy-MM-dd)
+            - 해당 날짜의 모든 음수량 기록을 시간순으로 반환합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "음수량 날짜별 조회 성공", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ResponseDateApi.WaterDateResponseApi.class))
+            }),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            }),
+            @ApiResponse(responseCode = "404", description = "반려동물 정보 없음", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            })
+    })
+    @GetMapping("/water/date")
+    public ResponseEntity<ResponseDTO<ResponseDateListDTO<ResponseDateDTO.WaterResponse>>> getWaterByDate(@Valid @ModelAttribute RequestDateDTO dto) {
+        log.info("Received request to get water intake records by date for pet ID: {} on date: {}", dto.getPetId(), dto.getDate());
+        ResponseDateListDTO<ResponseDateDTO.WaterResponse> result = queryService.getWaterByDate(dto);
+        log.info("Successfully retrieved water intake records for pet ID: {} on date: {}", dto.getPetId(), dto.getDate());
+
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_GET_RECORD_LIST.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_GET_RECORD_LIST, result));
+
+    }
 }

--- a/src/main/java/animal/diary/controller/RecordController.java
+++ b/src/main/java/animal/diary/controller/RecordController.java
@@ -8,6 +8,7 @@ import animal.diary.dto.api.RecordResponseApi;
 import animal.diary.dto.record.*;
 import animal.diary.dto.response.ErrorResponseDTO;
 import animal.diary.dto.response.ResponseDTO;
+import animal.diary.entity.record.state.LevelState;
 import animal.diary.exception.ImageSizeLimitException;
 import animal.diary.service.RecordService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -502,4 +503,37 @@ public class RecordController {
                 .status(SuccessCode.SUCCESS_SAVE_RECORD.getStatus().value())
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_SAVE_RECORD, result));
     }
+
+    // ============================================================ 음수량 기록
+    @Operation(summary = "음수량 기록", description = """
+            음수량을 기록합니다.
+            - 필수 필드: petId, amount
+            - amount: 음수량 (ml)
+            - 음수량은 반려동물이 하루 동안 마신 물의 양을 나타냅니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "음수량 기록 성공", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.WaterResponseDTO.class))
+            }),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            }),
+            @ApiResponse(responseCode = "404", description = "반려동물 정보 없음", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            })
+    })
+    @PostMapping(value = "/water")
+    public ResponseEntity<ResponseDTO<RecordResponseDTO.WaterResponseDTO>> recordWaterIntake(@Validated(LevelState.class) @RequestBody RecordWithOutImageDTO.WaterRecord dto) {
+        log.info("Received water intake record request for pet ID: {}", dto.getPetId());
+        RecordResponseDTO.WaterResponseDTO result = recordService.recordWater(dto);
+        log.info("Water intake record completed for pet ID: {}", dto.getPetId());
+
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_SAVE_RECORD.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_SAVE_RECORD, result));
+    }
+
 }

--- a/src/main/java/animal/diary/controller/RecordController.java
+++ b/src/main/java/animal/diary/controller/RecordController.java
@@ -35,7 +35,7 @@ import java.util.List;
 @Tag(name = "Record Controller", description = "기록 생성 관련 API")
 public class RecordController {
     private final RecordService recordService;
-    // (2.3, 2.4, 2.5, 2.6, 2.7,2.8,2.9,2.10,2.11,2.13,2.14,2.15,2.16)
+    // (2.3, 2.4, 2.5, 2.6, 2.7,2.8,2.9,2.10,2.11,2.13,2.14,2.15,2.16, 2.17)
     // ====================================================== 몸무게 기록
     @Operation(summary = "몸무게 기록", description = """
             몸무게를 기록합니다.
@@ -507,8 +507,8 @@ public class RecordController {
     // ============================================================ 음수량 기록
     @Operation(summary = "음수량 기록", description = """
             음수량을 기록합니다.
-            - 필수 필드: petId, amount
-            - amount: 음수량 (ml)
+            - 필수 필드: petId, state
+            - state: 음수량 (LOW, NORMAL, HIGH)
             - 음수량은 반려동물이 하루 동안 마신 물의 양을 나타냅니다.
             """)
     @ApiResponses(value = {

--- a/src/main/java/animal/diary/dto/RecordResponseDTO.java
+++ b/src/main/java/animal/diary/dto/RecordResponseDTO.java
@@ -270,4 +270,37 @@ public class RecordResponseDTO {
                     .build();
         }
     }
+
+    @Builder
+    @Getter
+    public class WaterResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
+        private Long petId;
+        // NORMAL = 보통, LOW = 적음, HIGH = 많음
+        @Schema(description = "물 섭취량 제목", example = "적음")
+        private String title;
+        @Schema(description = "물 섭취량 상태", example = "NORMAL")
+        private String state;
+        @Schema(description = "물 섭취량 기록 생성 시간", example = "2023-10-01T12:00:00")
+        private LocalDateTime createdAt;
+
+        public static WaterResponseDTO waterToDTO(Water water) {
+            // NORMAL = 보통, LOW = 적음, HIGH = 많음 -> title
+            // NONE은 존재하지 않음
+
+            String title = switch (water.getState()) {
+                case NORMAL -> "보통";
+                case LOW -> "적음";
+                case HIGH -> "많음";
+                default -> null;
+            };
+
+            return WaterResponseDTO.builder()
+                    .petId(water.getPet().getId())
+                    .title(title)
+                    .state(water.getState().name())
+                    .createdAt(water.getCreatedAt())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/animal/diary/dto/ResponseDateDTO.java
+++ b/src/main/java/animal/diary/dto/ResponseDateDTO.java
@@ -323,4 +323,35 @@ public class ResponseDateDTO {
         // Walking to DTO
 
     }
+
+    @Builder
+    @Getter
+    public class WaterResponse {
+        @Schema(description = "일기 ID", example = "1")
+        private Long diaryId;
+        // LOW(적음), NORMAL(보통), HIGH(많음)
+        @Schema(description = "제목", example = "적음")
+        private String title;
+        @Schema(description = "물 섭취량 상태 (LOW, NORMAL, HIGH)", example = "NORMAL")
+        private String state;
+        @Schema(type = "string", example = "14:30", description = "기록 시간 (HH:mm)")
+        private LocalTime createdTime;
+
+        public static WaterResponse waterToDTO(Water water) {
+            // LOW(적음), NORMAL(보통), HIGH(많음)
+            String title = switch (water.getState()) {
+                case LOW -> "적음";
+                case NORMAL -> "보통";
+                case HIGH -> "많음";
+                default -> "";
+            };
+
+            return WaterResponse.builder()
+                    .diaryId(water.getId())
+                    .title(title)
+                    .state(water.getState().name())
+                    .createdTime(water.getCreatedAt().toLocalTime())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/animal/diary/dto/api/ResponseDateApi.java
+++ b/src/main/java/animal/diary/dto/api/ResponseDateApi.java
@@ -66,8 +66,14 @@ public class ResponseDateApi extends ResponseDTO<ResponseDateListDTO<?>> {
         }
     }
 
-    public class WalkingDateResponseApi extends ResponseDTO<ResponseDateListDTO<RecordResponseDTO.WalkingResponseDTO>> {
+    public static class WalkingDateResponseApi extends ResponseDTO<ResponseDateListDTO<RecordResponseDTO.WalkingResponseDTO>> {
         public WalkingDateResponseApi(SuccessCode successCode, ResponseDateListDTO<RecordResponseDTO.WalkingResponseDTO> data) {
+            super(successCode, data);
+        }
+    }
+
+    public static class WaterDateResponseApi extends ResponseDTO<ResponseDateListDTO<ResponseDateDTO.StateResponse>> {
+        public WaterDateResponseApi(SuccessCode successCode, ResponseDateListDTO<ResponseDateDTO.StateResponse> data) {
             super(successCode, data);
         }
     }

--- a/src/main/java/animal/diary/dto/record/RecordWithOutImageDTO.java
+++ b/src/main/java/animal/diary/dto/record/RecordWithOutImageDTO.java
@@ -67,6 +67,26 @@ public class RecordWithOutImageDTO {
 
     @Builder
     @Getter
+    public static class WaterRecord {
+        @NotNull(message = "펫 ID는 필수입니다.")
+        @Schema(description = "펫 ID", example = "1")
+        private Long petId;
+
+        // level
+        @NotNull(groups = StateGroup.class, message = "물 섭취량은 필수입니다.")
+        @Schema(description = "가능한 값: LOW, NORMAL, HIGH", example = "NORMAL")
+        private String state;
+
+        public static Water toWaterEntity(WaterRecord dto, Pet pet) {
+            return Water.builder()
+                    .state(LevelState.fromString(dto.getState(), () -> new InvalidStateException("물 섭취량 상태가 올바르지 않습니다.")))
+                    .pet(pet)
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
     public static class RespiratoryRateAndHeartRateRecord {
         @NotNull(message = "펫 ID는 필수입니다.")
         @Schema(description = "펫 ID", example = "1")

--- a/src/main/java/animal/diary/entity/record/Water.java
+++ b/src/main/java/animal/diary/entity/record/Water.java
@@ -2,8 +2,16 @@ package animal.diary.entity.record;
 
 import animal.diary.entity.record.state.LevelState;
 import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
 public class Water extends Diary {
     private LevelState state;
 }

--- a/src/main/java/animal/diary/repository/WaterRepository.java
+++ b/src/main/java/animal/diary/repository/WaterRepository.java
@@ -3,5 +3,9 @@ package animal.diary.repository;
 import animal.diary.entity.record.Water;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface WaterRepository extends JpaRepository<Water, Long> {
+    List<Water> findAllByPetIdAndCreatedAtBetween(Long id, LocalDateTime localDateTime, LocalDateTime localDateTime1);
 }

--- a/src/main/java/animal/diary/repository/WaterRepository.java
+++ b/src/main/java/animal/diary/repository/WaterRepository.java
@@ -1,0 +1,7 @@
+package animal.diary.repository;
+
+import animal.diary.entity.record.Water;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaterRepository extends JpaRepository<Water, Long> {
+}

--- a/src/main/java/animal/diary/service/QueryService.java
+++ b/src/main/java/animal/diary/service/QueryService.java
@@ -39,6 +39,7 @@ public class QueryService {
     private final SnotRepository snotRepository;
     private final VomitingRepository vomitingRepository;
     private final WalkingRepository walkingRepository;
+    private final WaterRepository waterRepository;
 
     // 2.3몸무게 조회
     public ResponseDateListDTO<ResponseDateDTO.WeightResponse> getWeightsByDate(RequestDateDTO dto) {
@@ -488,5 +489,30 @@ public class QueryService {
     }
 
 
+    public ResponseDateListDTO<ResponseDateDTO.WaterResponse> getWaterByDate(RequestDateDTO dto) {
+        Pet pet = getPetOrThrow(dto.getPetId());
 
+        LocalDate date = dto.getDate();
+        validateDate(dto.getDate());
+
+        LocalDateTime[] range = getStartAndEndOfDay(dto.getDate());
+
+        log.info("Fetching water records for pet ID: {} on date: {}", pet.getId(), date);
+        List<Water> waterList = waterRepository.findAllByPetIdAndCreatedAtBetween(pet.getId(), range[0], range[1]);
+        log.info("Found {} water records for pet ID: {} on date: {}", waterList.size(), pet.getId(), date);
+
+        if (waterList.isEmpty()) {
+            throw new EmptyListException("비어었음");
+        }
+
+        List<ResponseDateDTO.WaterResponse> result = waterList.stream()
+                .map(ResponseDateDTO.WaterResponse::waterToDTO)
+                .toList();
+
+        return ResponseDateListDTO.<ResponseDateDTO.WaterResponse>builder()
+                .date(date)
+                .type(pet.getType().toString())
+                .dateDTOS(result)
+                .build();
+    }
 }

--- a/src/main/java/animal/diary/service/RecordService.java
+++ b/src/main/java/animal/diary/service/RecordService.java
@@ -35,6 +35,7 @@ public class RecordService {
     private final SnotRepository snotRepository;
     private final VomitingRepository vomitingRepository;
     private final WalkingRepository walkingRepository;
+    private final WaterRepository waterRepository;
     
     // 몸무게 기록
     public RecordResponseDTO.WeightResponseDTO recordWeight(RecordWithOutImageDTO.WeightRecordDTO dto) {
@@ -264,5 +265,14 @@ public class RecordService {
     }
 
 
+    public RecordResponseDTO.WaterResponseDTO recordWater(RecordWithOutImageDTO.WaterRecord dto) {
+        Pet pet = getPetOrThrow(dto.getPetId());
 
+        Water water = RecordWithOutImageDTO.WaterRecord.toWaterEntity(dto, pet);
+        log.info("Recording water intake for pet ID: {}, level: {}", pet.getId(), dto.getState());
+        waterRepository.save(water);
+        log.info("Successfully recorded water intake with ID: {}", water.getId());
+
+        return RecordResponseDTO.WaterResponseDTO.waterToDTO(water);
+    }
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #61

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
- 음수량 기록 API 추가 (POST /v1/records/water)
- WaterRecord DTO 엔티티 변환 메서드 추가
- Water 엔티티에 SuperBuilder, Getter 어노테이션 추가
- WaterRepository JPA 인터페이스 구현
- RecordService에 음수량 기록 로직 추가
- WaterResponseDTO 응답 DTO 추가 (상태별 제목 처리)
- LevelState 유효성 검증 지원 (LOW, NORMAL, HIGH)
- QueryController에 음수량 조회 주석 추가

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->