### PR TITLE
[Feat/#63] skin condition record

### DIFF
--- a/src/main/java/animal/diary/controller/QueryController.java
+++ b/src/main/java/animal/diary/controller/QueryController.java
@@ -477,4 +477,36 @@ public class QueryController {
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_GET_RECORD_LIST, result));
 
     }
+
+    // =========================================================== 피부 상태 조회
+    @Operation(summary = "피부 상태 날짜별 조회", description = """
+            특정 날짜의 피부 상태 기록을 조회합니다.
+            - 필수 필드: petId, date
+            - date: 조회할 날짜 (yyyy-MM-dd)
+            - 해당 날짜의 모든 피부 상태 기록을 시간순으로 반환합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "피부 상태 날짜별 조회 성공", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ResponseDateApi.SkinDateResponseApi.class))
+            }),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            }),
+            @ApiResponse(responseCode = "404", description = "반려동물 정보 없음", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            })
+    })
+    @GetMapping("/skin/date")
+    public ResponseEntity<ResponseDTO<ResponseDateListDTO<ResponseDateDTO.SkinResponse>>> getSkinByDate(@Valid @ModelAttribute RequestDateDTO dto) {
+        log.info("Received request to get skin records by date for pet ID: {} on date: {}", dto.getPetId(), dto.getDate());
+        ResponseDateListDTO<ResponseDateDTO.SkinResponse> result = queryService.getSkinByDate(dto);
+        log.info("Successfully retrieved skin records for pet ID: {} on date: {}", dto.getPetId(), dto.getDate());
+
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_GET_RECORD_LIST.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_GET_RECORD_LIST, result));
+    }
 }

--- a/src/main/java/animal/diary/controller/RecordController.java
+++ b/src/main/java/animal/diary/controller/RecordController.java
@@ -536,4 +536,39 @@ public class RecordController {
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_SAVE_RECORD, result));
     }
 
+    // =========================================================== 피부 상태 기록
+    @Operation(summary = "피부 상태 기록", description = """
+            피부 상태를 기록합니다.
+            - 필수 필드: petId, state
+            - state: 피부 상태 (0, 1, 2, 3)
+            - 이미지는 최대 10장까지 업로드 가능합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "피부 상태 기록 성공", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = RecordResponseDTO.SkinResponseDTO.class))
+            }),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            }),
+            @ApiResponse(responseCode = "404", description = "반려동물 정보 없음", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            })
+    })
+    @PostMapping(value = "/skin", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ResponseDTO<RecordResponseDTO.SkinResponseDTO>> recordSkin(
+            @RequestPart SkinRecordDTO dto,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+
+        log.info("Received skin record request for pet ID: {} with state: {}", dto.getPetId(), dto.getState());
+        RecordResponseDTO.SkinResponseDTO result = recordService.recordSkin(dto, images);
+        log.info("Skin record completed for pet ID: {}", dto.getPetId());
+
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_SAVE_RECORD.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_SAVE_RECORD, result));
+    }
+
 }

--- a/src/main/java/animal/diary/dto/RecordResponseDTO.java
+++ b/src/main/java/animal/diary/dto/RecordResponseDTO.java
@@ -303,4 +303,24 @@ public class RecordResponseDTO {
                     .build();
         }
     }
+
+    @Builder
+    @Getter
+    public class SkinResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
+        private Long petId;
+        // numberState
+        @Schema(description = "피부 상태", example = "0")
+        private String state;
+        @Schema(description = "피부 상태 기록 생성 시간", example = "2023-10-01T12:00:00")
+        private LocalDateTime createdAt;
+
+        public static SkinResponseDTO skinToDTO(Skin skin) {
+            return SkinResponseDTO.builder()
+                    .petId(skin.getPet().getId())
+                    .state(skin.getState().name())
+                    .createdAt(skin.getCreatedAt())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/animal/diary/dto/ResponseDateDTO.java
+++ b/src/main/java/animal/diary/dto/ResponseDateDTO.java
@@ -354,4 +354,35 @@ public class ResponseDateDTO {
                     .build();
         }
     }
+
+    @Builder
+    @Getter
+    public class SkinResponse {
+        @Schema(description = "일기 ID", example = "1")
+        private Long diaryId;
+        // 0단계, 1단계, 2단계, 3단계
+        @Schema(description = "제목", example = "1단계")
+        private String title;
+        @Schema(description = "피부 상태 (0,1,2,3)", example = "1")
+        private String state;
+        @Schema(description = "메모", example = "털이 많이 빠지고 있음")
+        private String memo;
+        @Schema(description = "이미지 URL 목록", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")
+        private List<String> imageUrls;
+        @Schema(type = "string", example = "14:30", description = "기록 시간 (HH:mm)")
+        private LocalTime createdTime;
+
+        public static SkinResponse skinToDTO(Skin skin, List<String> imageUrls) {
+            String title = skin.getState() + "단계";
+
+            return SkinResponse.builder()
+                    .diaryId(skin.getId())
+                    .title(title)
+                    .state(skin.getState().name())
+                    .memo(skin.getMemo() != null ? skin.getMemo() : null)
+                    .imageUrls(imageUrls != null ? imageUrls : List.of())
+                    .createdTime(skin.getCreatedAt().toLocalTime())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/animal/diary/dto/api/ResponseDateApi.java
+++ b/src/main/java/animal/diary/dto/api/ResponseDateApi.java
@@ -77,4 +77,10 @@ public class ResponseDateApi extends ResponseDTO<ResponseDateListDTO<?>> {
             super(successCode, data);
         }
     }
+
+    public static class SkinDateResponseApi extends ResponseDTO<ResponseDateListDTO<RecordResponseDTO.SkinResponseDTO>> {
+        public SkinDateResponseApi(SuccessCode successCode, ResponseDateListDTO<RecordResponseDTO.SkinResponseDTO> data) {
+            super(successCode, data);
+        }
+    }
 }

--- a/src/main/java/animal/diary/dto/record/SkinRecordDTO.java
+++ b/src/main/java/animal/diary/dto/record/SkinRecordDTO.java
@@ -30,6 +30,7 @@ public class SkinRecordDTO {
 
     public static Skin toEntity(SkinRecordDTO dto, Pet pet, List<String> imageUrls) {
         return Skin.builder()
+                // 유효성 검사
                 .state(NumberState.fromString(dto.getState()))
                 .memo(dto.getMemo())
                 .pet(pet)

--- a/src/main/java/animal/diary/repository/SkinRepository.java
+++ b/src/main/java/animal/diary/repository/SkinRepository.java
@@ -3,5 +3,9 @@ package animal.diary.repository;
 import animal.diary.entity.record.Skin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface SkinRepository extends JpaRepository<Skin, Long> {
+    List<Skin> findAllByPetIdAndCreatedAtBetween(Long id, LocalDateTime localDateTime, LocalDateTime localDateTime1);
 }

--- a/src/main/java/animal/diary/repository/SkinRepository.java
+++ b/src/main/java/animal/diary/repository/SkinRepository.java
@@ -1,0 +1,7 @@
+package animal.diary.repository;
+
+import animal.diary.entity.record.Skin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SkinRepository extends JpaRepository<Skin, Long> {
+}

--- a/src/main/java/animal/diary/service/QueryService.java
+++ b/src/main/java/animal/diary/service/QueryService.java
@@ -40,6 +40,7 @@ public class QueryService {
     private final VomitingRepository vomitingRepository;
     private final WalkingRepository walkingRepository;
     private final WaterRepository waterRepository;
+    private final SkinRepository skinRepository;
 
     // 2.3몸무게 조회
     public ResponseDateListDTO<ResponseDateDTO.WeightResponse> getWeightsByDate(RequestDateDTO dto) {
@@ -510,6 +511,45 @@ public class QueryService {
                 .toList();
 
         return ResponseDateListDTO.<ResponseDateDTO.WaterResponse>builder()
+                .date(date)
+                .type(pet.getType().toString())
+                .dateDTOS(result)
+                .build();
+    }
+
+    public ResponseDateListDTO<ResponseDateDTO.SkinResponse> getSkinByDate(RequestDateDTO dto) {
+        Pet pet = getPetOrThrow(dto.getPetId());
+
+        LocalDate date = dto.getDate();
+        validateDate(dto.getDate());
+
+        LocalDateTime[] range = getStartAndEndOfDay(dto.getDate());
+
+        log.info("Fetching skin records for pet ID: {} on date: {}", pet.getId(), date);
+        List<Skin> skinList = skinRepository.findAllByPetIdAndCreatedAtBetween(pet.getId(), range[0], range[1]);
+        log.info("Found {} skin records for pet ID: {} on date: {}", skinList.size(), pet.getId(), date);
+
+        if (skinList.isEmpty()) {
+            throw new EmptyListException("비어었음");
+        }
+
+        List<ResponseDateDTO.SkinResponse> result = skinList.stream().map(
+                skin -> {
+                    List<String> imageUrls = skin.getImageUrls();
+                    if (imageUrls == null || imageUrls.isEmpty()) {
+                        return ResponseDateDTO.SkinResponse.skinToDTO(skin, List.of());
+                    }
+
+                    // 스트림으로 변환하여 성능 향상
+                    List<String> imageCloudFrontUrls = imageUrls.stream()
+                            .map(cloudFrontUrlService::generateSignedUrl)
+                            .toList();
+
+                    return ResponseDateDTO.SkinResponse.skinToDTO(skin, imageCloudFrontUrls);
+                }
+        ).toList();
+
+        return ResponseDateListDTO.<ResponseDateDTO.SkinResponse>builder()
                 .date(date)
                 .type(pet.getType().toString())
                 .dateDTOS(result)


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #63

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
- 피부 상태 기록 API 추가 (POST /v1/records/skin)
- SkinRepository JPA 인터페이스 구현
- RecordService에 피부 상태 기록 로직 추가
- SkinResponseDTO 응답 DTO 추가
- 이미지 10장 제한 및 S3 업로드 지원
- NumberState 유효성 검증 지원 (0, 1, 2, 3)

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->