### PR TITLE
[Feat/#66] 배변 상태 기록 및 조회 API 완전 구현

### DIFF
--- a/src/main/java/animal/diary/controller/QueryController.java
+++ b/src/main/java/animal/diary/controller/QueryController.java
@@ -509,4 +509,36 @@ public class QueryController {
                 .status(SuccessCode.SUCCESS_GET_RECORD_LIST.getStatus().value())
                 .body(new ResponseDTO<>(SuccessCode.SUCCESS_GET_RECORD_LIST, result));
     }
+
+    // =========================================================== 배변 상태 조회
+    @Operation(summary = "배변 상태 날짜별 조회", description = """
+            특정 날짜의 배변 상태 기록을 조회합니다.
+            - 필수 필드: petId, date
+            - date: 조회할 날짜 (yyyy-MM-dd)
+            - 해당 날짜의 모든 배변 상태 기록을 시간순으로 반환합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "배변 상태 날짜별 조회 성공", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ResponseDateApi.DefecationDateResponseApi.class))
+            }),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            }),
+            @ApiResponse(responseCode = "404", description = "반려동물 정보 없음", content = {
+                    @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ErrorResponseDTO.class))
+            })
+    })
+    @GetMapping("/defecation/date")
+    public ResponseEntity<ResponseDTO<ResponseDateListDTO<ResponseDateDTO.DefecationResponse>>> getDefecationByDate(@Valid @ModelAttribute RequestDateDTO dto) {
+        log.info("Received request to get defecation records by date for pet ID: {} on date: {}", dto.getPetId(), dto.getDate());
+        ResponseDateListDTO<ResponseDateDTO.DefecationResponse> result = queryService.getDefecationByDate(dto);
+        log.info("Successfully retrieved defecation records for pet ID: {} on date: {}", dto.getPetId(), dto.getDate());
+
+        return ResponseEntity
+                .status(SuccessCode.SUCCESS_GET_RECORD_LIST.getStatus().value())
+                .body(new ResponseDTO<>(SuccessCode.SUCCESS_GET_RECORD_LIST, result));
+    }
 }

--- a/src/main/java/animal/diary/dto/RecordResponseDTO.java
+++ b/src/main/java/animal/diary/dto/RecordResponseDTO.java
@@ -323,4 +323,32 @@ public class RecordResponseDTO {
                     .build();
         }
     }
+
+    @Builder
+    @Getter
+    public class DefecationResponseDTO {
+        @Schema(description = "반려동물 ID", example = "1")
+        private Long petId;
+        @Schema(description = "배변량 상태", example = "NORMAL")
+        private String level;
+        @Schema(description = "대변 상태", example = "NORMAL")
+        private String state;
+        @Schema(description = "메모", example = "평소보다 단단한 편")
+        private String memo;
+        @Schema(description = "이미지 URL 목록", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")
+        private List<String> imageUrls;
+        @Schema(description = "배변 기록 생성 시간", example = "2023-10-01T12:00:00")
+        private LocalDateTime createdAt;
+
+        public static DefecationResponseDTO defecationToDTO(Defecation defecation) {
+            return DefecationResponseDTO.builder()
+                    .petId(defecation.getPet().getId())
+                    .level(defecation.getLevel().name())
+                    .state(defecation.getState() != null ? defecation.getState().name() : null)
+                    .memo(defecation.getMemo())
+                    .imageUrls(defecation.getImageUrls())
+                    .createdAt(defecation.getCreatedAt())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/animal/diary/dto/ResponseDateDTO.java
+++ b/src/main/java/animal/diary/dto/ResponseDateDTO.java
@@ -385,4 +385,43 @@ public class ResponseDateDTO {
                     .build();
         }
     }
+
+    @Builder
+    @Getter
+    public class DefecationResponse {
+        @Schema(description = "일기 ID", example = "1")
+        private Long diaryId;
+        @Schema(description = "제목", example = "보통")
+        private String title;
+        @Schema(description = "배변량 상태 (NONE, LOW, NORMAL, HIGH)", example = "NORMAL")
+        private String level;
+        @Schema(description = "대변 상태 (NORMAL, DIARRHEA, BLACK, BLOODY, ETC)", example = "NORMAL")
+        private String state;
+        @Schema(description = "메모", example = "평소보다 단단한 편")
+        private String memo;
+        @Schema(description = "이미지 URL 목록", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")
+        private List<String> imageUrls;
+        @Schema(type = "string", example = "14:30", description = "기록 시간 (HH:mm)")
+        private LocalTime createdTime;
+
+        public static DefecationResponse defecationToDTO(Defecation defecation, List<String> imageUrls) {
+            // 배변량에 따른 제목 설정
+            String title = switch (defecation.getLevel()) {
+                case NONE -> "없음";
+                case LOW -> "적음";
+                case NORMAL -> "보통";
+                case HIGH -> "많음";
+            };
+
+            return DefecationResponse.builder()
+                    .diaryId(defecation.getId())
+                    .title(title)
+                    .level(defecation.getLevel().name())
+                    .state(defecation.getState() != null ? defecation.getState().name() : null)
+                    .memo(defecation.getMemo())
+                    .imageUrls(imageUrls != null ? imageUrls : List.of())
+                    .createdTime(defecation.getCreatedAt().toLocalTime())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/animal/diary/dto/api/ResponseDateApi.java
+++ b/src/main/java/animal/diary/dto/api/ResponseDateApi.java
@@ -83,4 +83,10 @@ public class ResponseDateApi extends ResponseDTO<ResponseDateListDTO<?>> {
             super(successCode, data);
         }
     }
+
+    public static class DefecationDateResponseApi extends ResponseDTO<ResponseDateListDTO<ResponseDateDTO.DefecationResponse>> {
+        public DefecationDateResponseApi(SuccessCode successCode, ResponseDateListDTO<ResponseDateDTO.DefecationResponse> data) {
+            super(successCode, data);
+        }
+    }
 }

--- a/src/main/java/animal/diary/repository/DefecationRepository.java
+++ b/src/main/java/animal/diary/repository/DefecationRepository.java
@@ -1,0 +1,11 @@
+package animal.diary.repository;
+
+import animal.diary.entity.record.Defecation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DefecationRepository extends JpaRepository<Defecation, Long> {
+    List<Defecation> findAllByPetIdAndCreatedAtBetween(Long id, LocalDateTime localDateTime, LocalDateTime localDateTime1);
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #66

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 작업 내용

## 📢 To Reviewers
## 기록 API (POST /v1/records/defecation)
- 배변량: NONE, LOW, NORMAL, HIGH 지원
- 대변상태: NORMAL, DIARRHEA, BLACK, BLOODY, ETC 지원
- 복잡한 비즈니스 로직: NONE일 때 상태/메모 입력 불가
- 이미지 최대 10장 업로드 지원
- 기존 DefecationRecordDTO 유효성 검증 활용

## 조회 API (GET /v1/query/defecation/date)
- 날짜별 배변 기록 조회
- 제목: 없음/적음/보통/많음으로 표시
- CloudFront URL 서명 처리

## 구현 컴포넌트
- DefecationRepository: JPA 인터페이스
- DefecationResponseDTO: 기록 응답 DTO
- DefecationResponse: 조회 응답 DTO
- DefecationDateResponseApi: API 응답 클래스
- RecordService.recordDefecation(): 기록 로직
- QueryService.getDefecationByDate(): 조회 로직
## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->